### PR TITLE
Optimize enemy path finding

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -70,8 +70,13 @@ place_miner={
 
 2d/default_edge_connection_margin=32
 
+[physics]
+
+2d/run_on_separate_thread=true
+
 [rendering]
 
+textures/canvas_textures/default_texture_filter=0
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
 environment/defaults/default_clear_color=Color(0.0470588, 0.0470588, 0.0470588, 1)

--- a/src/enemies/enemy.gd
+++ b/src/enemies/enemy.gd
@@ -53,6 +53,8 @@ func _physics_process(_delta):
 	var query: PhysicsRayQueryParameters2D = PhysicsRayQueryParameters2D.create(
 		global_position, target.global_position
 	)
+	# Set collision mask to player (1), environment (3) and ores (5)
+	query.collision_mask = 0b00000000_00000000_00000000_00010101
 	var result: Dictionary = space_state.intersect_ray(query)
 
 	var next_path_position: Vector2

--- a/src/enemies/enemy.gd
+++ b/src/enemies/enemy.gd
@@ -23,6 +23,20 @@ func actor_setup():
 	start_navigating = true
 
 
+func _process(_delta):
+	if not target:
+		return
+
+	# TODO @Shinigami92 2023-11-13: the look at is just a rendering nice-to-have
+	# and so it does not need to be in a physics process
+	# hoverer, the look at could be extracted into a component and then iterated
+	# in an enemy manager and so it could be maybe a little bit more performant
+	# but for now this works and is good enough
+
+	# look at
+	animated_sprite.flip_h = global_position.x < target.global_position.x
+
+
 func _physics_process(_delta):
 	if not start_navigating:
 		return
@@ -33,10 +47,22 @@ func _physics_process(_delta):
 	# target position
 	var current_agent_position: Vector2 = global_position
 	navigation_agent.target_position = target.global_position
-	var next_path_position: Vector2 = navigation_agent.get_next_path_position()
+	# TODO @Shinigami92 2023-11-13: a call to `navigation_agent.get_next_path_position()`
+	# is very expensive and only makes around 60 enemies possible
+	# before calling it, the enemy could shoot a raycast to target and if it hits
+	# the target, the enemy could just move in straight line to the target
+	# and don't need to calculate a path
+	var space_state: PhysicsDirectSpaceState2D = get_world_2d().direct_space_state
+	var query: PhysicsRayQueryParameters2D = PhysicsRayQueryParameters2D.create(
+		global_position, target.global_position
+	)
+	var result: Dictionary = space_state.intersect_ray(query)
 
-	# look at
-	animated_sprite.flip_h = global_position.x < target.global_position.x
+	var next_path_position: Vector2
+	if result.collider == target:
+		next_path_position = navigation_agent.target_position
+	else:
+		next_path_position = navigation_agent.get_next_path_position()
 
 	# velocity
 	var new_velocity: Vector2 = next_path_position - current_agent_position

--- a/src/enemies/enemy.gd
+++ b/src/enemies/enemy.gd
@@ -5,7 +5,6 @@ extends CharacterBody2D
 
 var start_navigating: bool = false
 var target: Node2D
-var _next_path_position: Vector2
 
 @onready var navigation_agent: NavigationAgent2D = $NavigationAgent2D
 @onready var animated_sprite: AnimatedSprite2D = $AnimatedSprite2D
@@ -45,10 +44,10 @@ func _physics_process(_delta):
 
 	# target position
 	var current_agent_position: Vector2 = global_position
-	navigation_agent.target_position = target.global_position
+	var next_path_position = navigation_agent.get_next_path_position()
 
 	# velocity
-	var new_velocity: Vector2 = _next_path_position - current_agent_position
+	var new_velocity: Vector2 = next_path_position - current_agent_position
 	new_velocity = new_velocity.normalized()
 	new_velocity = new_velocity * movement_speed
 
@@ -60,27 +59,7 @@ func _update_navigation_path():
 	if not target:
 		return
 
-	# TODO @Shinigami92 2023-11-13: a call to `navigation_agent.get_next_path_position()`
-	# is very expensive and only makes around 60 enemies possible
-	# before calling it, the enemy could shoot a raycast to target and if it hits
-	# the target, the enemy could just move in straight line to the target
-	# and don't need to calculate a path
-	var space_state: PhysicsDirectSpaceState2D = get_world_2d().direct_space_state
-	var query: PhysicsRayQueryParameters2D = PhysicsRayQueryParameters2D.create(
-		global_position, target.global_position
-	)
-	# Set collision mask to player (1), environment (3) and ores (5)
-	query.collision_mask = 0b00000000_00000000_00000000_00010101
-	var result: Dictionary = space_state.intersect_ray(query)
-
-	if result.collider == target:
-		_next_path_position = navigation_agent.target_position
-	else:
-		_next_path_position = navigation_agent.get_next_path_position()
-
-
-#func _update_navigation_path2(_details: Dictionary):
-#	_update_navigation_path()
+	navigation_agent.target_position = target.global_position
 
 
 func take_damage():

--- a/src/enemies/enemy.gd
+++ b/src/enemies/enemy.gd
@@ -11,9 +11,6 @@ var target: Node2D
 
 
 func _ready():
-	navigation_agent.path_desired_distance = 4.0
-	navigation_agent.target_desired_distance = 4.0
-
 	call_deferred("actor_setup")
 
 

--- a/src/enemies/enemy.tscn
+++ b/src/enemies/enemy.tscn
@@ -56,7 +56,6 @@ shape = SubResource("RectangleShape2D_ldyd4")
 debug_color = Color(1, 0.00392157, 0.0745098, 0.0980392)
 
 [node name="NavigationAgent2D" type="NavigationAgent2D" parent="."]
-debug_enabled = true
 
 [node name="UpdateNavigationPathTimer" type="Timer" parent="."]
 wait_time = 0.33

--- a/src/enemies/enemy.tscn
+++ b/src/enemies/enemy.tscn
@@ -56,3 +56,8 @@ shape = SubResource("RectangleShape2D_ldyd4")
 debug_color = Color(1, 0.00392157, 0.0745098, 0.0980392)
 
 [node name="NavigationAgent2D" type="NavigationAgent2D" parent="."]
+debug_enabled = true
+
+[node name="UpdateNavigationPathTimer" type="Timer" parent="."]
+wait_time = 0.33
+autostart = true

--- a/src/enemies/enemy_spawner.gd
+++ b/src/enemies/enemy_spawner.gd
@@ -44,4 +44,4 @@ func _spawn_enemy():
 		3:
 			vec = Vector2(-960, random.randf_range(-540, 540))
 	enemy.global_position = player.global_position + vec
-	world.add_child(enemy)
+	world.call_deferred("add_child", enemy)

--- a/src/world/chunks/chunk.gd
+++ b/src/world/chunks/chunk.gd
@@ -5,6 +5,8 @@ extends Node2D
 const CHUNK_SIZE = 16
 const TILE_SIZE = 64
 
+var tile_size: Vector2 = Vector2(TILE_SIZE, TILE_SIZE)
+
 @onready var tile_map: TileMap = $TileMap
 @onready var visibility_notifier: VisibleOnScreenNotifier2D = $VisibleOnScreenNotifier2D
 
@@ -14,33 +16,86 @@ func _ready():
 	visibility_notifier.screen_exited.connect(tile_map.hide)
 	tile_map.visible = false
 
-	# check if each tile does not collide with another tile
-	for x in range(0, CHUNK_SIZE):
-		for y in range(0, CHUNK_SIZE):
-			var tile_coords: Vector2i = Vector2i(x, y)
-			var tile: int = tile_map.get_cell_source_id(0, tile_coords)
-			if tile == -1:
-				continue
-			var tile_pos: Vector2 = tile_map.global_position + (TILE_SIZE * Vector2(x, y))
-			var tile_size: Vector2 = Vector2(TILE_SIZE, TILE_SIZE)
-			var tile_rect: Rect2 = Rect2(tile_pos, tile_size)
-			var tile_colliders = get_tree().get_nodes_in_group("collider")
-			for collider in tile_colliders:
-				var collider_tile_map: TileMap = collider
+	var new_2d_region_rid: RID = NavigationServer2D.region_create()
+	var default_2d_map_rid: RID = get_world_2d().get_navigation_map()
+	NavigationServer2D.region_set_map(new_2d_region_rid, default_2d_map_rid)
 
-				for collider_tile in collider_tile_map.get_used_cells(0):
-					var collider_tile_data: TileData = collider_tile_map.get_cell_tile_data(
-						0, collider_tile
-					)
-					if not collider_tile_data.get_custom_data("wall"):
-						continue
-					var collider_tile_coords: Vector2i = collider_tile
-					var collider_tile_pos: Vector2 = (
-						collider_tile_map.global_position
-						+ (TILE_SIZE * Vector2(collider_tile_coords.x, collider_tile_coords.y))
-					)
-					var collider_tile_size: Vector2 = Vector2(TILE_SIZE, TILE_SIZE)
-					var collider_tile_rect: Rect2 = Rect2(collider_tile_pos, collider_tile_size)
-					if collider_tile_rect.intersects(tile_rect):
-						tile_map.erase_cell(0, tile_coords)
-						break
+	var new_navigation_polygon: NavigationPolygon = NavigationPolygon.new()
+	var new_outline: PackedVector2Array = PackedVector2Array(
+		[
+			global_position,
+			global_position + Vector2(1024.0, 0.0),
+			global_position + Vector2(1024.0, 1024.0),
+			global_position + Vector2(0.0, 1024.0),
+		]
+	)
+	new_navigation_polygon.add_outline(new_outline)
+	new_navigation_polygon.make_polygons_from_outlines()
+
+	NavigationServer2D.region_set_navigation_polygon(new_2d_region_rid, new_navigation_polygon)
+
+# 	var chunk_rect: Rect2 = Rect2(tile_map.global_position, tile_size * CHUNK_SIZE)
+
+# 	# check if each tile does not collide with another tile
+# 	var tile_map_colliders = get_tree().get_nodes_in_group("collider")
+
+# 	for collider in tile_map_colliders:
+# 		if not collider is TileMap:
+# 			continue
+
+# 		var collider_tile_map: TileMap = collider
+
+# 		var collider_bounds = _calculate_bounds(collider_tile_map)
+
+# 		if chunk_rect.intersects(collider_bounds):
+# 			for x in range(0, CHUNK_SIZE):
+# 				for y in range(0, CHUNK_SIZE):
+# 					var tile_coords: Vector2i = Vector2i(x, y)
+# 					var tile: int = tile_map.get_cell_source_id(0, tile_coords)
+
+# 					if tile == -1:
+# 						continue
+
+# 					var tile_pos: Vector2 = tile_map.global_position + (TILE_SIZE * Vector2(x, y))
+# 					var tile_rect: Rect2 = Rect2(tile_pos, tile_size)
+
+# 					for collider_tile in collider_tile_map.get_used_cells(0):
+# 						var collider_tile_data: TileData = collider_tile_map.get_cell_tile_data(
+# 							0, collider_tile
+# 						)
+
+# 						if not collider_tile_data.get_custom_data("wall"):
+# 							continue
+# 						var collider_tile_coords: Vector2i = collider_tile
+# 						var collider_tile_pos: Vector2 = (
+# 							collider_tile_map.global_position
+# 							+ (TILE_SIZE * Vector2(collider_tile_coords.x, collider_tile_coords.y))
+# 						)
+# 						var collider_tile_rect: Rect2 = Rect2(collider_tile_pos, tile_size)
+
+# 						if collider_tile_rect.intersects(tile_rect):
+# 							tile_map.erase_cell(0, tile_coords)
+# 							break
+
+# func _calculate_bounds(tilemap: TileMap) -> Rect2:
+# 	var used_cells: Array[Vector2i] = tilemap.get_used_cells(0)
+
+# 	var min_x: float = used_cells[0].x
+# 	var max_x: float = used_cells[0].x
+# 	var min_y: float = used_cells[0].y
+# 	var max_y: float = used_cells[0].y
+
+# 	for pos in used_cells:
+# 		if pos.x < min_x:
+# 			min_x = pos.x
+# 		elif pos.x > max_x:
+# 			max_x = pos.x
+
+# 		if pos.y < min_y:
+# 			min_y = pos.y
+# 		elif pos.y > max_y:
+# 			max_y = pos.y
+
+# 	return Rect2(
+# 		Vector2(min_x, min_y) * TILE_SIZE, Vector2(max_x - min_x + 1, max_y - min_y + 1) * TILE_SIZE
+# 	)

--- a/src/world/chunks/chunk.tscn
+++ b/src/world/chunks/chunk.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://c0twdv0q44nlq"]
+[gd_scene load_steps=13 format=3 uid="uid://c0twdv0q44nlq"]
 
 [ext_resource type="Script" path="res://src/world/chunks/chunk.gd" id="1_0faai"]
 [ext_resource type="Texture2D" uid="uid://0mo6y3vutc8a" path="res://assets/tilesets/autotile_tileset.png" id="2_bufog"]
@@ -22,11 +22,6 @@ outlines = Array[PackedVector2Array]([PackedVector2Array(-16, -16, 0, -16, 0, 16
 vertices = PackedVector2Array(-16, -16, 16, -16, 16, 0, -16, 0)
 polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
 outlines = Array[PackedVector2Array]([PackedVector2Array(-16, -16, 16, -16, 16, 0, -16, 0)])
-
-[sub_resource type="NavigationPolygon" id="NavigationPolygon_rsyak"]
-vertices = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
-polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
-outlines = Array[PackedVector2Array]([PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)])
 
 [sub_resource type="NavigationPolygon" id="NavigationPolygon_4y3fg"]
 vertices = PackedVector2Array(0, 0, 16, 0, 16, 16, 0, 16)
@@ -139,7 +134,6 @@ texture_region_size = Vector2i(64, 64)
 6:2/0 = 0
 6:2/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 6:2/0/physics_layer_0/angular_velocity = 0.0
-6:2/0/navigation_layer_0/polygon = SubResource("NavigationPolygon_rsyak")
 7:2/0 = 0
 7:2/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 7:2/0/physics_layer_0/angular_velocity = 0.0

--- a/src/world/chunks/outer_world_chunk_gen.gd
+++ b/src/world/chunks/outer_world_chunk_gen.gd
@@ -4,31 +4,42 @@ extends Marker2D
 const CHUNK_SIZE = 16
 const TILE_SIZE = 64
 const CHUNK_WIDTH = CHUNK_SIZE * TILE_SIZE
+const CHUNK_SCENE: PackedScene = preload("res://src/world/chunks/chunk.tscn")
 
-@export var chunk_scene: PackedScene
 @export var player: Player
 
-var _chunks = {}
+var _chunks: Dictionary = {}
+
+@onready var chunk_generation_timer: Timer = $ChunkGenerationTimer
+
+# TODO @Shinigami92 2023-11-14: https://dennissmuda.com/blog/godot-chunking-tutorial
 
 
 func _ready():
-	pass
+	chunk_generation_timer.timeout.connect(_on_chunk_generation_timer_timeout)
 
 
-func _process(_delta):
+func _on_chunk_generation_timer_timeout():
 	var player_chunk = Vector2i(floor(player.global_position / CHUNK_WIDTH))
 
 	for dx in [-1, 0, 1]:
 		for dy in [-1, 0, 1]:
 			var chunk_coord = player_chunk + Vector2i(dx, dy)
+
 			if not _chunks.has(chunk_coord):
-				var chunk: Chunk = chunk_scene.instantiate()
-				chunk.position = chunk_coord * CHUNK_WIDTH
-				add_child(chunk)
+				var chunk: Chunk = _create_chunk(chunk_coord)
 				_chunks[chunk_coord] = chunk
+				call_deferred("add_child", chunk)
 
 	for chunk_coord in _chunks:
-		if (chunk_coord - player_chunk).length() >= 3:
+		if (chunk_coord - player_chunk).length() >= 8:
 			var chunk = _chunks.get(chunk_coord)
+
 			if _chunks.erase(chunk_coord):
-				chunk.queue_free()
+				chunk.call_deferred("queue_free")
+
+
+func _create_chunk(chunk_coord: Vector2i) -> Chunk:
+	var chunk: Chunk = CHUNK_SCENE.instantiate()
+	chunk.position = chunk_coord * CHUNK_WIDTH
+	return chunk

--- a/src/world/chunks/outer_world_chunk_gen.tscn
+++ b/src/world/chunks/outer_world_chunk_gen.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3 uid="uid://0oong4n83xxw"]
+
+[ext_resource type="Script" path="res://src/world/chunks/outer_world_chunk_gen.gd" id="1_1ngbh"]
+
+[node name="OuterWorldChunkGen" type="Marker2D"]
+script = ExtResource("1_1ngbh")
+
+[node name="ChunkGenerationTimer" type="Timer" parent="."]
+wait_time = 0.125
+autostart = true

--- a/src/world/world.tscn
+++ b/src/world/world.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=12 format=3 uid="uid://brr557s2lfy5s"]
+[gd_scene load_steps=11 format=3 uid="uid://brr557s2lfy5s"]
 
-[ext_resource type="Script" path="res://src/world/chunks/outer_world_chunk_gen.gd" id="1_foqy2"]
-[ext_resource type="PackedScene" uid="uid://c0twdv0q44nlq" path="res://src/world/chunks/chunk.tscn" id="2_ki4jy"]
+[ext_resource type="PackedScene" uid="uid://0oong4n83xxw" path="res://src/world/chunks/outer_world_chunk_gen.tscn" id="1_va6hf"]
 [ext_resource type="PackedScene" uid="uid://dquy7u8pg5yad" path="res://src/enemies/enemy_spawner.tscn" id="3_cpcw5"]
 [ext_resource type="PackedScene" uid="uid://qi2widkoej4c" path="res://src/enemies/enemy.tscn" id="4_yny3t"]
 [ext_resource type="PackedScene" uid="uid://cdn6vrsj310n4" path="res://src/world/player_hub/player_hub.tscn" id="5_66ymf"]
@@ -14,10 +13,7 @@
 
 [node name="World" type="Node2D"]
 
-[node name="OuterWorldChunkGen" type="Marker2D" parent="." node_paths=PackedStringArray("player")]
-unique_name_in_owner = true
-script = ExtResource("1_foqy2")
-chunk_scene = ExtResource("2_ki4jy")
+[node name="OuterWorldChunkGen" parent="." node_paths=PackedStringArray("player") instance=ExtResource("1_va6hf")]
 player = NodePath("../Player")
 
 [node name="EnemySpawner" parent="." node_paths=PackedStringArray("player", "world", "player_hub") instance=ExtResource("3_cpcw5")]


### PR DESCRIPTION
- https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html#code-example
- https://docs.godotengine.org/en/stable/classes/class_navigationagent2d.html#signals

~ 260 enemies @ 60 fps, but only when no new path needs to be recalculated (player stands still)
previously around 50 enemies were already problematic

<img width="390" alt="Screenshot 2023-11-14 at 16 52 15" src="https://github.com/Shinigami92/ore-seeker/assets/7195563/f81b006c-86d2-430a-9133-ef35fe41143d"> <img width="390" alt="Screenshot 2023-11-14 at 16 52 55" src="https://github.com/Shinigami92/ore-seeker/assets/7195563/c1e29d42-2d0a-44fc-9359-26e669fc7408">

---

`get_next_path_position` should be called on every `_physics_process`, the agent's target can be set with a delay, so the path gets cached behind the scenes
https://github.com/godotengine/godot/blob/fc79201851a16215f9554884aa242ed957801b10/scene/2d/navigation_agent_2d.cpp#L559

When a new chunk is generated, all enemies in the scene needs to recalculate their meshes, due to the agent's nav-mesh got updated :thinking:  
Not sure yet how to optimize that
Chunk's nav-mesh gets merged based on random generated tilemap

