### PR TITLE
Simplify enemy navigation and cleanup

### DIFF
--- a/src/enemies/enemy.gd
+++ b/src/enemies/enemy.gd
@@ -3,49 +3,52 @@ extends CharacterBody2D
 
 @export var movement_speed: float = 150.0
 
-var start_navigating: bool = false
-var target: Node2D
+var target: Node2D = null
+var last_position: Vector2
+var stuck_counter: int = 0
 
-@onready var navigation_agent: NavigationAgent2D = $NavigationAgent2D
 @onready var animated_sprite: AnimatedSprite2D = $AnimatedSprite2D
+@onready var stuck_timer: Timer = $StuckTimer
 
 
-func _ready():
-	navigation_agent.path_desired_distance = 4.0
-	navigation_agent.target_desired_distance = 4.0
-
-	call_deferred("actor_setup")
+func _ready() -> void:
+	stuck_timer.timeout.connect(_on_stuck_timer_timeout)
 
 
-func actor_setup():
-	await get_tree().physics_frame
-
-	start_navigating = true
+func _process(_delta: float) -> void:
+	animated_sprite.flip_h = global_position.x < target.global_position.x
 
 
-func _physics_process(_delta):
-	if not start_navigating:
-		return
-
+func _physics_process(_delta: float) -> void:
 	if not target:
 		return
 
-	# target position
-	var current_agent_position: Vector2 = global_position
-	navigation_agent.target_position = target.global_position
-	var next_path_position: Vector2 = navigation_agent.get_next_path_position()
-
-	# look at
-	animated_sprite.flip_h = global_position.x < target.global_position.x
-
-	# velocity
-	var new_velocity: Vector2 = next_path_position - current_agent_position
-	new_velocity = new_velocity.normalized()
-	new_velocity = new_velocity * movement_speed
+	var new_velocity: Vector2 = target.global_position - global_position
+	new_velocity = new_velocity.normalized() * movement_speed
 
 	velocity = new_velocity
 	move_and_slide()
 
 
-func take_damage():
+func _on_stuck_timer_timeout() -> void:
+	# Check if the enemy is stuck by comparing its current position to its last position
+	# If the enemy has not moved for 3 seconds, it will take damage
+	# This is to prevent enemies from getting stuck on walls
+
+	if not last_position:
+		last_position = global_position
+		return
+
+	if last_position.distance_to(global_position) < 4.0:
+		stuck_counter += 1
+
+		if stuck_counter >= 3:
+			take_damage()
+	else:
+		stuck_counter = 0
+
+	last_position = global_position
+
+
+func take_damage() -> void:
 	queue_free()

--- a/src/enemies/enemy.tscn
+++ b/src/enemies/enemy.tscn
@@ -38,21 +38,25 @@ animations = [{
 "speed": 5.0
 }]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_ldyd4"]
-size = Vector2(32, 16)
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_40kw3"]
+radius = 6.5
+height = 33.0
 
 [node name="Enemy" type="CharacterBody2D" groups=["Enemy"]]
-scale = Vector2(2, 2)
+scale = Vector2(3, 3)
 collision_layer = 2
 collision_mask = 31
 script = ExtResource("1_xs55b")
+movement_speed = 100.0
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 sprite_frames = SubResource("SpriteFrames_pe6cc")
 autoplay = "default"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." groups=["Enemy"]]
-shape = SubResource("RectangleShape2D_ldyd4")
+rotation = 1.5708
+shape = SubResource("CapsuleShape2D_40kw3")
 debug_color = Color(1, 0.00392157, 0.0745098, 0.0980392)
 
-[node name="NavigationAgent2D" type="NavigationAgent2D" parent="."]
+[node name="StuckTimer" type="Timer" parent="."]
+autostart = true

--- a/src/enemies/enemy_spawner.gd
+++ b/src/enemies/enemy_spawner.gd
@@ -1,34 +1,35 @@
 class_name EnemySpawner
 extends Marker2D
 
+const ENEMY_SCENE: PackedScene = preload("res://src/enemies/enemy.tscn")
+
 @export var player: Player
 @export var world: Node2D
 @export var player_hub: PlayerHub
-@export var enemy_scene: PackedScene
 
-var random = RandomNumberGenerator.new()
+var random: RandomNumberGenerator = RandomNumberGenerator.new()
 
 @onready var spawn_interval_timer: Timer = $SpawnIntervalTimer
 
 
-func _ready():
+func _ready() -> void:
 	player_hub.player_entered.connect(_on_player_entered_hub)
 	player_hub.player_exited.connect(_on_player_exited_hub)
 	spawn_interval_timer.timeout.connect(_spawn_enemy)
 
 
-func _on_player_entered_hub():
+func _on_player_entered_hub() -> void:
 	spawn_interval_timer.stop()
 
 
-func _on_player_exited_hub():
+func _on_player_exited_hub() -> void:
 	spawn_interval_timer.start()
 
 
-func _spawn_enemy():
-	var enemy: Enemy = enemy_scene.instantiate()
+func _spawn_enemy() -> void:
+	var enemy: Enemy = ENEMY_SCENE.instantiate()
 	enemy.target = player
-	var side = random.randi_range(0, 3)
+	var side: int = random.randi_range(0, 3)
 	var vec: Vector2
 	match side:
 		# top

--- a/src/enemies/enemy_spawner.tscn
+++ b/src/enemies/enemy_spawner.tscn
@@ -7,3 +7,4 @@ script = ExtResource("1_fdvvw")
 
 [node name="SpawnIntervalTimer" type="Timer" parent="."]
 process_callback = 0
+wait_time = 0.2

--- a/src/hud/crosshair.gd
+++ b/src/hud/crosshair.gd
@@ -2,9 +2,9 @@ class_name Crosshair
 extends Sprite2D
 
 
-func _ready():
+func _ready() -> void:
 	Input.set_mouse_mode(Input.MOUSE_MODE_HIDDEN)
 
 
-func _process(_delta):
+func _process(_delta: float) -> void:
 	global_position = get_global_mouse_position()

--- a/src/hud/fps_counter.gd
+++ b/src/hud/fps_counter.gd
@@ -14,11 +14,11 @@ var current_fps: float = 0
 var max_samples: int = 0
 
 
-func _ready():
+func _ready() -> void:
 	max_samples = Engine.physics_ticks_per_second * sample_seconds
 
 
-func _physics_process(_delta):
+func _physics_process(_delta: float) -> void:
 	current_fps = Engine.get_frames_per_second()
 
 	total_fps += current_fps
@@ -35,7 +35,7 @@ func _physics_process(_delta):
 	_update_label()
 
 
-func _update_label():
+func _update_label() -> void:
 	text = (
 		"FPS: %d | Min: %d | Max: %d | Avg: %d"
 		% [current_fps, min_fps, max_fps, int(total_fps / fps_samples.size())]

--- a/src/hud/hud.gd
+++ b/src/hud/hud.gd
@@ -6,9 +6,9 @@ extends Camera2D
 @onready var player_carried_dirithium_label: Label = $PlayerCarriedDirithium
 
 
-func _ready():
+func _ready() -> void:
 	player.carried_dirithium_changed.connect(_redraw_player_carried_dirithium_label)
 
 
-func _redraw_player_carried_dirithium_label(carried_dirithium: int):
+func _redraw_player_carried_dirithium_label(carried_dirithium: int) -> void:
 	player_carried_dirithium_label.text = "Carried Dirithium: %d" % carried_dirithium

--- a/src/miners/miner.gd
+++ b/src/miners/miner.gd
@@ -9,18 +9,18 @@ var mined_amount: int = 0
 @onready var label: Label = $Label
 
 
-func init(placed_on: Ore):
+func init(placed_on: Ore) -> void:
 	self.placed_on = placed_on
 
 
-func _ready():
+func _ready() -> void:
 	mining_interval_timer.timeout.connect(_on_mining_interval_timer)
 	mining_progress_bar.max_value = mining_interval_timer.wait_time
 
 	_redraw_label()
 
 
-func _process(_delta):
+func _process(_delta: float) -> void:
 	if placed_on.is_depleted:
 		mining_interval_timer.stop()
 		mining_progress_bar.value = 0
@@ -29,13 +29,13 @@ func _process(_delta):
 		mining_progress_bar.value = mining_interval_timer.time_left
 
 
-func _on_mining_interval_timer():
+func _on_mining_interval_timer() -> void:
 	if not placed_on.is_depleted:
 		mined_amount += placed_on.gain_resource()
 		_redraw_label()
 
 
-func _on_body_entered(body: Node):
+func _on_body_entered(body: Node2D) -> void:
 	if body is Player:
 		body.carried_dirithium += mined_amount
 		body.carried_dirithium_changed.emit(body.carried_dirithium)
@@ -43,5 +43,5 @@ func _on_body_entered(body: Node):
 		_redraw_label()
 
 
-func _redraw_label():
+func _redraw_label() -> void:
 	label.text = "%d Dirithium" % mined_amount

--- a/src/player/player.gd
+++ b/src/player/player.gd
@@ -5,25 +5,27 @@ signal carried_dirithium_changed(new_value: int)
 
 @export var speed: float = 300.0
 
-var weapon: Node2D
+var weapon: Node2D = null
 
 var carried_dirithium: int = 0
 
 
-func _ready():
-	var revolver_scene = load("res://src/weapons/revolver/revolver.tscn")
+func _ready() -> void:
+	var revolver_scene: PackedScene = load("res://src/weapons/revolver/revolver.tscn")
 	weapon = revolver_scene.instantiate()
 	add_child(weapon)
 
 
-func get_input():
-	var input_direction = Input.get_vector("move_left", "move_right", "move_up", "move_down")
+func get_input() -> void:
+	var input_direction: Vector2 = Input.get_vector(
+		"move_left", "move_right", "move_up", "move_down"
+	)
 	velocity = input_direction * speed
 
 	if weapon != null and Input.is_action_pressed("shoot"):
 		weapon.shoot()
 
 
-func _physics_process(_delta):
+func _physics_process(_delta: float) -> void:
 	get_input()
 	move_and_slide()

--- a/src/weapons/bullet.gd
+++ b/src/weapons/bullet.gd
@@ -7,7 +7,7 @@ extends Area2D
 var _traveled_distance: float = 0.0
 
 
-func _physics_process(delta):
+func _physics_process(delta: float) -> void:
 	_traveled_distance += speed * delta
 	position += transform.x * speed * delta
 
@@ -15,7 +15,7 @@ func _physics_process(delta):
 		queue_free()
 
 
-func _on_area_2d_body_entered(body):
+func _on_area_2d_body_entered(body: Node2D) -> void:
 	if body.has_method("take_damage"):
 		body.take_damage()
 

--- a/src/weapons/bullet.tscn
+++ b/src/weapons/bullet.tscn
@@ -44,7 +44,7 @@ radius = 3.0
 height = 16.0
 
 [node name="Area2D" type="Area2D"]
-scale = Vector2(2, 2)
+scale = Vector2(3, 3)
 collision_layer = 8
 collision_mask = 22
 script = ExtResource("1_56vju")

--- a/src/weapons/revolver/revolver.gd
+++ b/src/weapons/revolver/revolver.gd
@@ -11,13 +11,13 @@ var ammo: int = max_ammo
 @onready var reload_interval_timer: Timer = $ReloadIntervalTimer
 
 
-func shoot():
+func shoot() -> void:
 	if ammo < 0 or not reload_interval_timer.is_stopped() or not shoot_interval_timer.is_stopped():
 		return
 
 	shoot_interval_timer.start()
 
-	var bullet = BULLET_SCENE.instantiate()
+	var bullet: Bullet = BULLET_SCENE.instantiate()
 	get_tree().root.add_child(bullet)
 	bullet.global_position = global_position
 	bullet.look_at(get_global_mouse_position())
@@ -28,7 +28,7 @@ func shoot():
 		reload()
 
 
-func reload():
+func reload() -> void:
 	if not reload_interval_timer.is_stopped():
 		return
 

--- a/src/weapons/revolver/revolver.tscn
+++ b/src/weapons/revolver/revolver.tscn
@@ -7,9 +7,10 @@ script = ExtResource("1_r04ll")
 
 [node name="ShootIntervalTimer" type="Timer" parent="."]
 process_callback = 0
-wait_time = 0.3
+wait_time = 0.1
 one_shot = true
 
 [node name="ReloadIntervalTimer" type="Timer" parent="."]
 process_callback = 0
+wait_time = 0.4
 one_shot = true

--- a/src/world/chunks/chunk.gd
+++ b/src/world/chunks/chunk.gd
@@ -5,7 +5,7 @@ extends Node2D
 @onready var visibility_notifier: VisibleOnScreenNotifier2D = $VisibleOnScreenNotifier2D
 
 
-func _ready():
+func _ready() -> void:
 	visibility_notifier.screen_entered.connect(tile_map.show)
 	visibility_notifier.screen_exited.connect(tile_map.hide)
 	tile_map.visible = false

--- a/src/world/chunks/chunk.tscn
+++ b/src/world/chunks/chunk.tscn
@@ -1,52 +1,7 @@
-[gd_scene load_steps=14 format=3 uid="uid://c0twdv0q44nlq"]
+[gd_scene load_steps=5 format=3 uid="uid://c0twdv0q44nlq"]
 
 [ext_resource type="Script" path="res://src/world/chunks/chunk.gd" id="1_0faai"]
 [ext_resource type="Texture2D" uid="uid://0mo6y3vutc8a" path="res://assets/tilesets/autotile_tileset.png" id="2_bufog"]
-
-[sub_resource type="NavigationPolygon" id="NavigationPolygon_h6v47"]
-vertices = PackedVector2Array(-16, -32, 32, -32, 32, 32, -16, 32)
-polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
-outlines = Array[PackedVector2Array]([PackedVector2Array(-16, -32, 32, -32, 32, 32, -16, 32)])
-
-[sub_resource type="NavigationPolygon" id="NavigationPolygon_qkxmv"]
-vertices = PackedVector2Array(-32, -16, 32, -16, 32, 32, -32, 32)
-polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
-outlines = Array[PackedVector2Array]([PackedVector2Array(-32, -16, 32, -16, 32, 32, -32, 32)])
-
-[sub_resource type="NavigationPolygon" id="NavigationPolygon_koig3"]
-vertices = PackedVector2Array(-32, -32, 16, -32, 16, 32, -32, 32)
-polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
-outlines = Array[PackedVector2Array]([PackedVector2Array(-32, -32, 16, -32, 16, 32, -32, 32)])
-
-[sub_resource type="NavigationPolygon" id="NavigationPolygon_0qkqa"]
-vertices = PackedVector2Array(-32, -32, 32, -32, 32, 16, -32, 16)
-polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
-outlines = Array[PackedVector2Array]([PackedVector2Array(-32, -32, 32, -32, 32, 16, -32, 16)])
-
-[sub_resource type="NavigationPolygon" id="NavigationPolygon_bhjtn"]
-vertices = PackedVector2Array(-32, -32, 32, -32, 32, 32, -32, 32)
-polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
-outlines = Array[PackedVector2Array]([PackedVector2Array(-32, -32, 32, -32, 32, 32, -32, 32)])
-
-[sub_resource type="NavigationPolygon" id="NavigationPolygon_m4vsx"]
-vertices = PackedVector2Array(-16, -16, 32, -16, 32, 32, -16, 32)
-polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
-outlines = Array[PackedVector2Array]([PackedVector2Array(-16, -16, 32, -16, 32, 32, -16, 32)])
-
-[sub_resource type="NavigationPolygon" id="NavigationPolygon_lfeir"]
-vertices = PackedVector2Array(-16, -32, 32, -32, 32, 16, -16, 16)
-polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
-outlines = Array[PackedVector2Array]([PackedVector2Array(-16, -32, 32, -32, 32, 16, -16, 16)])
-
-[sub_resource type="NavigationPolygon" id="NavigationPolygon_gf545"]
-vertices = PackedVector2Array(-32, -16, 16, -16, 16, 32, -32, 32)
-polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
-outlines = Array[PackedVector2Array]([PackedVector2Array(-32, -16, 16, -16, 16, 32, -32, 32)])
-
-[sub_resource type="NavigationPolygon" id="NavigationPolygon_e7d6w"]
-vertices = PackedVector2Array(-32, -32, 16, -32, 16, 16, -32, 16)
-polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
-outlines = Array[PackedVector2Array]([PackedVector2Array(-32, -32, 16, -32, 16, 16, -32, 16)])
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_itkwg"]
 texture = ExtResource("2_bufog")
@@ -77,12 +32,10 @@ texture_region_size = Vector2i(64, 64)
 7:0/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 7:0/0/physics_layer_0/angular_velocity = 0.0
 7:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-32, -32, 32, -32, 32, -16, -16, -16, -16, 32, -32, 32)
-7:0/0/navigation_layer_0/polygon = SubResource("NavigationPolygon_m4vsx")
 8:0/0 = 0
 8:0/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 8:0/0/physics_layer_0/angular_velocity = 0.0
 8:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-32, -32, 32, -32, 32, 32, 16, 32, 16, -16, -32, -16)
-8:0/0/navigation_layer_0/polygon = SubResource("NavigationPolygon_gf545")
 0:1/0 = 0
 0:1/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 0:1/0/physics_layer_0/angular_velocity = 0.0
@@ -108,12 +61,10 @@ texture_region_size = Vector2i(64, 64)
 7:1/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 7:1/0/physics_layer_0/angular_velocity = 0.0
 7:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-32, -32, -16, -32, -16, 16, 32, 16, 32, 32, -32, 32)
-7:1/0/navigation_layer_0/polygon = SubResource("NavigationPolygon_lfeir")
 8:1/0 = 0
 8:1/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 8:1/0/physics_layer_0/angular_velocity = 0.0
 8:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(16, 16, 16, -32, 32, -32, 32, 32, -32, 32, -32, 16)
-8:1/0/navigation_layer_0/polygon = SubResource("NavigationPolygon_e7d6w")
 0:2/0 = 0
 0:2/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 0:2/0/physics_layer_0/angular_velocity = 0.0
@@ -130,16 +81,13 @@ texture_region_size = Vector2i(64, 64)
 4:2/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 4:2/0/physics_layer_0/angular_velocity = 0.0
 4:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-32, -32, -16, -32, -16, 32, -32, 32)
-4:2/0/navigation_layer_0/polygon = SubResource("NavigationPolygon_h6v47")
 5:2/0 = 0
 5:2/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 5:2/0/physics_layer_0/angular_velocity = 0.0
 5:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(16, -32, 32, -32, 32, 32, 16, 32)
-5:2/0/navigation_layer_0/polygon = SubResource("NavigationPolygon_koig3")
 6:2/0 = 0
 6:2/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 6:2/0/physics_layer_0/angular_velocity = 0.0
-6:2/0/navigation_layer_0/polygon = SubResource("NavigationPolygon_bhjtn")
 7:2/0 = 0
 7:2/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 7:2/0/physics_layer_0/angular_velocity = 0.0
@@ -162,12 +110,10 @@ texture_region_size = Vector2i(64, 64)
 4:3/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 4:3/0/physics_layer_0/angular_velocity = 0.0
 4:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-32, -32, 32, -32, 32, -16, -32, -16)
-4:3/0/navigation_layer_0/polygon = SubResource("NavigationPolygon_qkxmv")
 5:3/0 = 0
 5:3/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 5:3/0/physics_layer_0/angular_velocity = 0.0
 5:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-32, 16, 32, 16, 32, 32, -32, 32)
-5:3/0/navigation_layer_0/polygon = SubResource("NavigationPolygon_0qkqa")
 6:3/0 = 0
 6:3/0/physics_layer_0/linear_velocity = Vector2(0, 0)
 6:3/0/physics_layer_0/angular_velocity = 0.0
@@ -236,7 +182,6 @@ texture_region_size = Vector2i(64, 64)
 tile_size = Vector2i(64, 64)
 physics_layer_0/collision_layer = 4
 physics_layer_0/collision_mask = 11
-navigation_layer_0/layers = 1
 sources/0 = SubResource("TileSetAtlasSource_itkwg")
 
 [node name="Chunk" type="Node2D"]

--- a/src/world/chunks/outer_world_chunk_gen.gd
+++ b/src/world/chunks/outer_world_chunk_gen.gd
@@ -4,31 +4,29 @@ extends Marker2D
 const CHUNK_SIZE = 16
 const TILE_SIZE = 64
 const CHUNK_WIDTH = CHUNK_SIZE * TILE_SIZE
+const CHUNK_SCENE: PackedScene = preload("res://src/world/chunks/chunk.tscn")
 
-@export var chunk_scene: PackedScene
 @export var player: Player
 
-var _chunks = {}
+var _chunks: Dictionary = {}
 
 
-func _ready():
-	pass
-
-
-func _process(_delta):
-	var player_chunk = Vector2i(floor(player.global_position / CHUNK_WIDTH))
+func _process(_delta: float) -> void:
+	var player_chunk: Vector2i = Vector2i(floor(player.global_position / CHUNK_WIDTH))
 
 	for dx in [-1, 0, 1]:
 		for dy in [-1, 0, 1]:
-			var chunk_coord = player_chunk + Vector2i(dx, dy)
+			var chunk_coord: Vector2i = player_chunk + Vector2i(dx, dy)
+
 			if not _chunks.has(chunk_coord):
-				var chunk: Chunk = chunk_scene.instantiate()
+				var chunk: Chunk = CHUNK_SCENE.instantiate()
 				chunk.position = chunk_coord * CHUNK_WIDTH
 				add_child(chunk)
 				_chunks[chunk_coord] = chunk
 
 	for chunk_coord in _chunks:
 		if (chunk_coord - player_chunk).length() >= 3:
-			var chunk = _chunks.get(chunk_coord)
+			var chunk: Chunk = _chunks.get(chunk_coord)
+
 			if _chunks.erase(chunk_coord):
 				chunk.queue_free()

--- a/src/world/ores/ore.gd
+++ b/src/world/ores/ore.gd
@@ -1,7 +1,8 @@
 class_name Ore
 extends StaticBody2D
 
-@export var miner_scene: PackedScene
+const MINER_SCENE: PackedScene = preload("res://src/miners/miner.tscn")
+
 @export var amount_of_resources: int = 100
 
 var is_depleted: bool = false
@@ -12,13 +13,13 @@ var _player_is_near: bool = false
 @onready var label: Label = $Label
 
 
-func _ready():
+func _ready() -> void:
 	label.text = "%d Dirithium" % amount_of_resources
 
 
-func _physics_process(_delta):
+func _physics_process(_delta: float) -> void:
 	if _player_is_near and not _miner and Input.is_action_just_pressed("place_miner"):
-		_miner = miner_scene.instantiate()
+		_miner = MINER_SCENE.instantiate()
 		_miner.init(self)
 		add_child(_miner)
 
@@ -39,9 +40,9 @@ func gain_resource(take: int = 1) -> int:
 	return 0
 
 
-func _on_player_nearby_detector_body_entered(_body):
+func _on_player_nearby_detector_body_entered(_body: Node2D) -> void:
 	_player_is_near = true
 
 
-func _on_player_nearby_detector_body_exited(_body):
+func _on_player_nearby_detector_body_exited(_body: Node2D) -> void:
 	_player_is_near = false

--- a/src/world/player_hub/player_hub.gd
+++ b/src/world/player_hub/player_hub.gd
@@ -6,17 +6,17 @@ signal player_entered
 
 var _x: float
 
-@onready var player_door_detector = $PlayerDoorDetector
+@onready var player_door_detector: Area2D = $PlayerDoorDetector
 
 
-func _ready():
+func _ready() -> void:
 	_x = (
 		player_door_detector.global_position.x
 		+ player_door_detector.get_node("CollisionShape2D").shape.get_rect().size.x / 2
 	)
 
 
-func _on_area_2d_body_exited(body: Node2D):
+func _on_area_2d_body_exited(body: Node2D) -> void:
 	if body is Player:
 		if body.global_position.x > _x:
 			player_exited.emit()

--- a/src/world/player_hub/player_ore_delivery_detector.gd
+++ b/src/world/player_hub/player_ore_delivery_detector.gd
@@ -6,7 +6,7 @@ var stored_dirithium_amount: int = 0
 @onready var label: Label = $Label
 
 
-func _on_body_entered(body: Node):
+func _on_body_entered(body: Node2D) -> void:
 	if body is Player:
 		stored_dirithium_amount += body.carried_dirithium
 		body.carried_dirithium = 0

--- a/src/world/world.tscn
+++ b/src/world/world.tscn
@@ -1,9 +1,7 @@
-[gd_scene load_steps=12 format=3 uid="uid://brr557s2lfy5s"]
+[gd_scene load_steps=10 format=3 uid="uid://brr557s2lfy5s"]
 
 [ext_resource type="Script" path="res://src/world/chunks/outer_world_chunk_gen.gd" id="1_foqy2"]
-[ext_resource type="PackedScene" uid="uid://c0twdv0q44nlq" path="res://src/world/chunks/chunk.tscn" id="2_ki4jy"]
 [ext_resource type="PackedScene" uid="uid://dquy7u8pg5yad" path="res://src/enemies/enemy_spawner.tscn" id="3_cpcw5"]
-[ext_resource type="PackedScene" uid="uid://qi2widkoej4c" path="res://src/enemies/enemy.tscn" id="4_yny3t"]
 [ext_resource type="PackedScene" uid="uid://cdn6vrsj310n4" path="res://src/world/player_hub/player_hub.tscn" id="5_66ymf"]
 [ext_resource type="PackedScene" uid="uid://ceys4vrcavapp" path="res://src/player/player.tscn" id="6_s68k4"]
 [ext_resource type="Script" path="res://src/hud/hud.gd" id="7_1w8fk"]
@@ -15,16 +13,13 @@
 [node name="World" type="Node2D"]
 
 [node name="OuterWorldChunkGen" type="Marker2D" parent="." node_paths=PackedStringArray("player")]
-unique_name_in_owner = true
 script = ExtResource("1_foqy2")
-chunk_scene = ExtResource("2_ki4jy")
 player = NodePath("../Player")
 
 [node name="EnemySpawner" parent="." node_paths=PackedStringArray("player", "world", "player_hub") instance=ExtResource("3_cpcw5")]
 player = NodePath("../Player")
 world = NodePath("..")
 player_hub = NodePath("../PlayerHub")
-enemy_scene = ExtResource("4_yny3t")
 
 [node name="PlayerHub" parent="." instance=ExtResource("5_66ymf")]
 


### PR DESCRIPTION
Instead of generating a Navigation Mesh and recalculate paths for all enemies, we simplify drastically by letting enemies just move in direction of the player.
If an enemy gets stuck, it will take damage and potentially die.
This is not very relevant for the player, because there will be so many enemies, that this does not affect the experience.

Doing this strategy lets us spawn hundreds of enemies instead of ~60 (see #26 / #27)
- #26
- #27

---

Additionally, this PR cleaned up the code, because I just want to have the cleaned code in the main branch